### PR TITLE
Fix MMC-hint

### DIFF
--- a/enumerateForge.py
+++ b/enumerateForge.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 import os
 import re
 import sys
@@ -57,7 +56,7 @@ class MojangLibrary (JsonObject):
 
 class PolyMCLibrary (MojangLibrary):
     url = StringProperty(exclude_if_none=True, default=None)
-    pmcHint = StringProperty(name="PMC-hint", exclude_if_none=True, default=None)
+    mmcHint = StringProperty(name="MMC-hint", exclude_if_none=True, default=None)  # this is supposed to be MMC-hint!
 
 
 def GetLibraryDownload (library : PolyMCLibrary):
@@ -65,7 +64,7 @@ def GetLibraryDownload (library : PolyMCLibrary):
         raise Exception('Natives are not handled yet')
 
     name = library.name
-    if library.pmcHint == 'forge-pack-xz':
+    if library.mmcHint == 'forge-pack-xz':
         kind = DownloadType.FORGE_XZ
         name.extension = 'jar.pack.xz'
     else:

--- a/generateForge.py
+++ b/generateForge.py
@@ -88,7 +88,7 @@ def versionFromProfile(profile, version):
         else:
             ourLib.url = forgeLib.url
         #if forgeLib.checksums and len(forgeLib.checksums) == 2:
-        #    ourLib.pmcHint = "forge-pack-xz"
+        #    ourLib.mmcHint = "forge-pack-xz"
         libs.append(ourLib)
     result.libraries = libs
     result.order = 5

--- a/generateLiteloader.py
+++ b/generateLiteloader.py
@@ -48,7 +48,7 @@ def processArtefacts(mcVersion, liteloader, notSnapshots):
             url = "http://dl.liteloader.com/versions/"
         )
         if not notSnapshots:
-            liteloaderLib.pmcHint = "always-stale"
+            liteloaderLib.mmcHint = "always-stale"
         libraries.append(liteloaderLib)
         version.libraries = libraries
         versions.append(version)

--- a/metautil.py
+++ b/metautil.py
@@ -247,7 +247,7 @@ def validateSupportedPolyMCVersion(version):
 
 class PolyMCLibrary (MojangLibrary):
     url = StringProperty(exclude_if_none=True, default=None)
-    pmcHint = StringProperty(name="PMC-hint", exclude_if_none=True, default=None)
+    mmcHint = StringProperty(name="MMC-hint", exclude_if_none=True, default=None)  # this is supposed to be MMC-hint!
 
 class VersionedJsonObject(JsonObject):
     formatVersion = IntegerProperty(default=CurrentPolyMCFormatVersion, validators=validateSupportedPolyMCVersion)


### PR DESCRIPTION
Apparently this was changed by #2.

This is totally wrong. The launcher expects `MMC-hint` and not `PMC-hint`. As an example this is one of the files using this: https://meta.polymc.org/v1/com.mumfrey.liteloader/1.11-SNAPSHOT.json