### PR TITLE
Allow for static LWJGL's

### DIFF
--- a/generateMojang.py
+++ b/generateMojang.py
@@ -5,7 +5,6 @@ from collections import defaultdict, namedtuple
 from operator import attrgetter
 from pprint import pprint
 from typing import Optional
-import shutil
 
 from meta.common import ensure_component_dir, polymc_path, upstream_path, static_path
 from meta.common.mojang import VERSION_MANIFEST_FILE, MINECRAFT_COMPONENT, LWJGL3_COMPONENT, LWJGL_COMPONENT, \

--- a/generateMojang.py
+++ b/generateMojang.py
@@ -5,6 +5,7 @@ from collections import defaultdict, namedtuple
 from operator import attrgetter
 from pprint import pprint
 from typing import Optional
+import shutil
 
 from meta.common import ensure_component_dir, polymc_path, upstream_path, static_path
 from meta.common.mojang import VERSION_MANIFEST_FILE, MINECRAFT_COMPONENT, LWJGL3_COMPONENT, LWJGL_COMPONENT, \
@@ -175,13 +176,24 @@ def is_macos_only(rules: Optional[MojangRules]):
 def process_single_variant(lwjgl_variant: MetaVersion):
     lwjgl_version = lwjgl_variant.version
     v = copy.deepcopy(lwjgl_variant)
+
     if lwjgl_version[0] == '2':
+        static_filename = os.path.join(STATIC_DIR, LWJGL_COMPONENT, f"{lwjgl_version}.json")
         filename = os.path.join(PMC_DIR, LWJGL_COMPONENT, f"{lwjgl_version}.json")
+        if os.path.isfile(static_filename):
+            v = MetaVersion.parse_file(static_filename)
+            print("LWJGL2 is static:", v.version)
+
         v.name = 'LWJGL 2'
         v.uid = LWJGL_COMPONENT
         v.conflicts = [Dependency(uid=LWJGL3_COMPONENT)]
     elif lwjgl_version[0] == '3':
+        static_filename = os.path.join(STATIC_DIR, LWJGL3_COMPONENT, f"{lwjgl_version}.json")
         filename = os.path.join(PMC_DIR, LWJGL3_COMPONENT, f"{lwjgl_version}.json")
+        if os.path.isfile(static_filename):
+            v = MetaVersion.parse_file(static_filename)
+            print("LWJGL3 is static:", v.version)
+
         v.name = 'LWJGL 3'
         v.uid = LWJGL3_COMPONENT
         v.conflicts = [Dependency(uid=LWJGL_COMPONENT)]


### PR DESCRIPTION
this allows to put org.lwjgl or org.lwjgl3 folder in static, which will allow for bsd natives and more things.
this still generates from mojang unless there is a static one present, eliminating the risk of mojang updating and stuff breaking
I haven't added any static ones in this PR yet, but this allows for that in the future

I will also do a few changes in the launcher to ease choosing natives based on architecture