### PR TITLE
Add LWJGL 3.3.6 and Windows on ARM support

### DIFF
--- a/generateMojang.py
+++ b/generateMojang.py
@@ -64,6 +64,7 @@ LOG4J_HASHES = {
 # We want versions that contain natives for all platforms. If there are multiple, pick the latest one
 # LWJGL versions we want
 PASS_VARIANTS = [
+    "2b00f31688148fc95dbc8c8ef37308942cf0dce0",  # 3.3.6
     "6f32ef730d05562ede7db0b845b72ea16dd239d5",  # 3.3.3 (2024-05-29 12:04:43+00:00)
     "765b4ab443051d286bdbb1c19cd7dc86b0792dce",  # 3.3.2 (2024-01-17 13:19:20+00:00)
     "54c4fb1d6a96ac3007c947bf310c8bcf94a862be",  # 3.3.1 (2023-04-20 11:55:19+00:00) split natives, with WoA natives

--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -982,7 +982,7 @@
           "classifiers": {
             "natives-linux-arm32": {
               "sha1": "3af5599c74dd76dd8dbb567b3f9b4963a6abeed5",
-              "size": 56388,						
+              "size": 56388,
               "url": "https://github.com/theofficialgman/lwjgl3-binaries-arm32/raw/lwjgl-3.2.2/lwjgl-opengl-natives-linux-arm32.jar"
             }
           }
@@ -1609,15 +1609,23 @@
     }
   },
   {
-    "_comment": "Only allow windows-arm64 for existing LWJGL 3.3.1",
+    "_comment": "Only allow windows-arm64 for existing LWJGL 3.3.3",
     "match": [
-      "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-openal-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.3.1",
-      "org.lwjgl:lwjgl-natives-windows-arm64:3.3.1"
+      "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-openal-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-natives-windows-arm64:3.3.3",
+      "org.lwjgl:lwjgl-freetype-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-openal-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-natives-windows-arm64:3.3.6"
     ],
     "override": {
       "rules": [


### PR DESCRIPTION
Updates the Windows on ARM natives to the latest version so it should
actually work.

Ported from https://git.crueter.xyz/PolyMC/meta-scripts

Signed-off-by: crueter <crueter@eden-emu.dev>
