### PR TITLE
Add LWJGL 3.4.1 support and update macOS-arm64 natives

### DIFF
--- a/generateMojang.py
+++ b/generateMojang.py
@@ -64,6 +64,7 @@ LOG4J_HASHES = {
 # We want versions that contain natives for all platforms. If there are multiple, pick the latest one
 # LWJGL versions we want
 PASS_VARIANTS = [
+    "1fd0e4d1f0f7c97e8765a69d38225e1f27ee14ef", # 3.4.1
     "2b00f31688148fc95dbc8c8ef37308942cf0dce0",  # 3.3.6
     "6f32ef730d05562ede7db0b845b72ea16dd239d5",  # 3.3.3 (2024-05-29 12:04:43+00:00)
     "765b4ab443051d286bdbb1c19cd7dc86b0792dce",  # 3.3.2 (2024-01-17 13:19:20+00:00)

--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -1609,7 +1609,7 @@
     }
   },
   {
-    "_comment": "Only allow windows-arm64 for existing LWJGL 3.3.3",
+    "_comment": "Only allow windows-arm64 for existing LWJGL 3.3.3, 3.3.6, and 3.4.1",
     "match": [
       "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.3.3",
       "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.3.3",
@@ -1625,7 +1625,15 @@
       "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.3.6",
       "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.3.6",
       "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.3.6",
-      "org.lwjgl:lwjgl-natives-windows-arm64:3.3.6"
+      "org.lwjgl:lwjgl-natives-windows-arm64:3.3.6",
+      "org.lwjgl:lwjgl-freetype-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-glfw-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-jemalloc-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-openal-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-natives-windows-arm64:3.4.1"
     ],
     "override": {
       "rules": [
@@ -2019,39 +2027,40 @@
     }
   },
   {
-    "_comment": "Add osx-arm64 support for LWJGL 3.3.2",
+    "_comment": "Add osx-arm64 support for LWJGL 3.3.2, 3.3.3, 3.3.6, and 3.4.1",
     "match": [
       "org.lwjgl:lwjgl-freetype-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.2",
-      "org.lwjgl:lwjgl-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.2",
-      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.2"
-    ],
-    "override": {
-      "rules": [
-        {
-          "action": "allow",
-          "os": {
-            "name": "osx-arm64"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "_comment": "Add osx-arm64 support for LWJGL 3.3.3",
-    "match": [
+      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.2",
+      "org.lwjgl:lwjgl-natives-macos-arm64:3.3.2",
       "org.lwjgl:lwjgl-freetype-natives-macos-arm64:3.3.3",
       "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.3",
       "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.3",
-      "org.lwjgl:lwjgl-natives-macos-arm64:3.3.3",
       "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.3",
       "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.3",
       "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.3",
-      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.3"
+      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.3",
+      "org.lwjgl:lwjgl-natives-macos-arm64:3.3.3",
+      "org.lwjgl:lwjgl-freetype-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-natives-macos-arm64:3.3.6",
+      "org.lwjgl:lwjgl-freetype-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-glfw-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-jemalloc-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-openal-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-natives-macos-arm64:3.4.1"
     ],
     "override": {
       "rules": [


### PR DESCRIPTION
Fixes script build.

Ported from https://git.crueter.xyz/PolyMC/meta-scripts/commit/50365873b3aa28ad51c4fdb0627dd82f36251e52

Signed-off-by: crueter <crueter@eden-emu.dev>
