### PR TITLE
Fix Python error in Neoforge

### DIFF
--- a/meta/model/neoforge.py
+++ b/meta/model/neoforge.py
@@ -27,7 +27,8 @@ class NeoForgeEntry(MetaBase):
         return self.version.split('-')[1] if self.mc_version == "1.20.1" else self.version
 
     def installer_filename(self):
-        return f"{"forge" if self.mc_version == "1.20.1" else "neoforge"}-{self.version}-installer.jar"
+        loader = "forge" if self.mc_version == "1.20.1" else "neoforge"
+        return f"{loader}-{self.version}-installer.jar"
 
     def installer_url(self):
         name = "forge" if self.mc_version == "1.20.1" else "neoforge"


### PR DESCRIPTION
I think this might be causing the meta-polymc updates to fail. If it
doesn't, I have no idea anymore.

Ported from https://git.crueter.xyz/PolyMC/meta-scripts/commit/50365873b3aa28ad51c4fdb0627dd82f36251e52

If this doesn't work then we should have someone else control the
auto-update, imo. It builds fine on my server's meta scripts, with a Python 3.10 installation.

Signed-off-by: crueter <crueter@eden-emu.dev>
