### PR TITLE
Add Vulkan support

### DIFF
--- a/generateMojang.py
+++ b/generateMojang.py
@@ -64,7 +64,7 @@ LOG4J_HASHES = {
 # We want versions that contain natives for all platforms. If there are multiple, pick the latest one
 # LWJGL versions we want
 PASS_VARIANTS = [
-    "1fd0e4d1f0f7c97e8765a69d38225e1f27ee14ef", # 3.4.1
+    "472ee33f7a1294822aa2d617cd6ccdfd92f949a0",  # 3.4.1, but with Vulkan
     "2b00f31688148fc95dbc8c8ef37308942cf0dce0",  # 3.3.6
     "6f32ef730d05562ede7db0b845b72ea16dd239d5",  # 3.3.3 (2024-05-29 12:04:43+00:00)
     "765b4ab443051d286bdbb1c19cd7dc86b0792dce",  # 3.3.2 (2024-01-17 13:19:20+00:00)
@@ -82,6 +82,7 @@ PASS_VARIANTS = [
 
 # LWJGL versions we def. don't want!
 BAD_VARIANTS = [
+    "1fd0e4d1f0f7c97e8765a69d38225e1f27ee14ef",  # 3.4.1, but without Vulkan
     "73974b3af2afeb5b272ffbadcd7963014387c84f",  # 3.3.3 (2024-05-15 12:00:35+00:00)
     "8a9b08f11271eb4de3b50e5d069949500b2c7bc1",  # 3.3.3 (2024-04-16 11:57:30+00:00)
     "79bde9e46e9ad9accebda11e8293ed08d80dbdc3",  # 3.3.2 (2023-09-05 12:06:20+00:00)

--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -434,7 +434,11 @@
       "org.lwjgl:lwjgl-opengl-natives-macos-arm64:3.4.1",
       "org.lwjgl:lwjgl-stb-natives-macos-arm64:3.4.1",
       "org.lwjgl:lwjgl-tinyfd-natives-macos-arm64:3.4.1",
-      "org.lwjgl:lwjgl-natives-macos-arm64:3.4.1"
+      "org.lwjgl:lwjgl-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-vulkan-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-shaderc-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-spvc-natives-macos-arm64:3.4.1",
+      "org.lwjgl:lwjgl-vma-natives-macos-arm64:3.4.1"
     ],
     "override": {
       "rules": [
@@ -488,7 +492,10 @@
       "org.lwjgl:lwjgl-opengl-natives-linux-arm64:3.4.1",
       "org.lwjgl:lwjgl-stb-natives-linux-arm64:3.4.1",
       "org.lwjgl:lwjgl-tinyfd-natives-linux-arm64:3.4.1",
-      "org.lwjgl:lwjgl-natives-linux-arm64:3.4.1"
+      "org.lwjgl:lwjgl-natives-linux-arm64:3.4.1",
+      "org.lwjgl:lwjgl-shaderc-natives-linux-arm64:3.4.1",
+      "org.lwjgl:lwjgl-spvc-natives-linux-arm64:3.4.1",
+      "org.lwjgl:lwjgl-vma-natives-linux-arm64:3.4.1"
     ],
     "override": {
       "rules": [
@@ -542,7 +549,10 @@
       "org.lwjgl:lwjgl-opengl-natives-linux-arm32:3.4.1",
       "org.lwjgl:lwjgl-stb-natives-linux-arm32:3.4.1",
       "org.lwjgl:lwjgl-tinyfd-natives-linux-arm32:3.4.1",
-      "org.lwjgl:lwjgl-natives-linux-arm32:3.4.1"
+      "org.lwjgl:lwjgl-natives-linux-arm32:3.4.1",
+      "org.lwjgl:lwjgl-shaderc-natives-linux-arm32:3.4.1",
+      "org.lwjgl:lwjgl-spvc-natives-linux-arm32:3.4.1",
+      "org.lwjgl:lwjgl-vma-natives-linux-arm32:3.4.1"
     ],
     "override": {
       "rules": [
@@ -596,7 +606,10 @@
       "org.lwjgl:lwjgl-opengl-natives-windows-arm64:3.4.1",
       "org.lwjgl:lwjgl-stb-natives-windows-arm64:3.4.1",
       "org.lwjgl:lwjgl-tinyfd-natives-windows-arm64:3.4.1",
-      "org.lwjgl:lwjgl-natives-windows-arm64:3.4.1"
+      "org.lwjgl:lwjgl-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-shaderc-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-spvc-natives-windows-arm64:3.4.1",
+      "org.lwjgl:lwjgl-vma-natives-windows-arm64:3.4.1"
     ],
     "override": {
       "rules": [


### PR DESCRIPTION
- Updated LWJGL to the version that actually has vulkan
- Added ARM overrides for all platforms
  * Note that macOS is the only one that has vulkan natives...

Signed-off-by: crueter <crueter@eden-emu.dev>
