### PR TITLE
Add Linux RISC-V support

### DIFF
--- a/meta/model/__init__.py
+++ b/meta/model/__init__.py
@@ -216,7 +216,7 @@ class MojangLibraryDownloads(MetaBase):
 class OSRule(MetaBase):
     @validator("name")
     def name_must_be_os(cls, v):
-        assert v in ["osx", "linux", "windows", "windows-arm64", "osx-arm64", "linux-arm64", "linux-arm32"]
+        assert v in ["osx", "linux", "windows", "windows-arm64", "osx-arm64", "linux-arm64", "linux-arm32", "linux-riscv64"]
         return v
 
     name: str

--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -621,5 +621,39 @@
         }
       ]
     }
+  },
+  {
+    "_comment": "Add linux-riscv64 support for LWJGL 3.3.6-3.4.1",
+    "match": [
+      "org.lwjgl:lwjgl-freetype-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-glfw-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-jemalloc-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-openal-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-opengl-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-stb-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-tinyfd-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-natives-linux-riscv64:3.3.6",
+      "org.lwjgl:lwjgl-freetype-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-glfw-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-jemalloc-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-openal-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-opengl-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-stb-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-tinyfd-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-shaderc-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-spvc-natives-linux-riscv64:3.4.1",
+      "org.lwjgl:lwjgl-vma-natives-linux-riscv64:3.4.1"
+    ],
+    "override": {
+      "rules": [
+        {
+          "action": "allow",
+          "os": {
+            "name": "linux-riscv64"
+          }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Adds linux-riscv64 to supported platforms. May need additional work in
PolyMC side???

Closes #28 

Signed-off-by: crueter <crueter@eden-emu.dev>
