### PR TITLE
Fix LWJGL + unsafe jar

### DIFF
--- a/generateMojang.py
+++ b/generateMojang.py
@@ -64,7 +64,7 @@ LOG4J_HASHES = {
 # We want versions that contain natives for all platforms. If there are multiple, pick the latest one
 # LWJGL versions we want
 PASS_VARIANTS = [
-    "472ee33f7a1294822aa2d617cd6ccdfd92f949a0",  # 3.4.1 but with Vulkan
+    "0ab5c885c21dfd8133277e8f557839f5fab35311",  # 3.4.1
     "2b00f31688148fc95dbc8c8ef37308942cf0dce0",  # 3.3.6
     "6f32ef730d05562ede7db0b845b72ea16dd239d5",  # 3.3.3 (2024-05-29 12:04:43+00:00)
     "765b4ab443051d286bdbb1c19cd7dc86b0792dce",  # 3.3.2 (2024-01-17 13:19:20+00:00)
@@ -82,6 +82,7 @@ PASS_VARIANTS = [
 
 # LWJGL versions we def. don't want!
 BAD_VARIANTS = [
+    "472ee33f7a1294822aa2d617cd6ccdfd92f949a0",  # 3.4.1, marked as bad by Mojang
     "1fd0e4d1f0f7c97e8765a69d38225e1f27ee14ef",  # 3.4.1, but without Vulkan
     "73974b3af2afeb5b272ffbadcd7963014387c84f",  # 3.3.3 (2024-05-15 12:00:35+00:00)
     "8a9b08f11271eb4de3b50e5d069949500b2c7bc1",  # 3.3.3 (2024-04-16 11:57:30+00:00)

--- a/patches/common.sh
+++ b/patches/common.sh
@@ -64,6 +64,11 @@ match() {
 		for lib in $(libs "$platform" "$version"); do
 			echo "org.lwjgl:$lib:$version"
 		done
+
+		# mojang added an unsafe variant for some reason
+		if [ "$version" = "3.4.1" ]; then
+			echo "org.lwjgl:lwjgl:$version:unsafe"
+		fi
 	done | jq -Rn '[inputs]'
 }
 
@@ -82,7 +87,24 @@ artifact() {
 	url="$1"
 
 	tmp=$(mktemp)
-	curl -sL "$url" -o "$tmp" --fail
+
+	TRIES=0
+	while [ "$TRIES" -lt 10 ]; do
+		if ! curl -sSL "$url" -o "$tmp" --fail; then
+			echo "-- Warning: $url failed to download, trying again in 2s" >&2
+			sleep 2
+			TRIES=$((TRIES+1))
+		else
+			break
+		fi
+	done
+
+	if [ "$TRIES" -eq 10 ]; then
+		echo "-- $url failed to download after 10 tries" >&2
+		[ ! -f "$tmp" ] || rm -f "$tmp"
+		exit 1
+	fi
+
 	sha1=$(sha1sum "$tmp" | awk '{print $1}')
 	size=$(stat -c %s "$tmp")
 

--- a/patches/generated/linux-lwjgl3.json
+++ b/patches/generated/linux-lwjgl3.json
@@ -629,7 +629,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -1462,7 +1463,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -1837,7 +1839,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -2192,7 +2195,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {

--- a/static/mojang/library-patches.json
+++ b/static/mojang/library-patches.json
@@ -2347,7 +2347,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -3180,7 +3181,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -3555,7 +3557,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {
@@ -3910,7 +3913,8 @@
       "org.lwjgl:lwjgl:3.4.1",
       "org.lwjgl:lwjgl-shaderc:3.4.1",
       "org.lwjgl:lwjgl-spvc:3.4.1",
-      "org.lwjgl:lwjgl-vma:3.4.1"
+      "org.lwjgl:lwjgl-vma:3.4.1",
+      "org.lwjgl:lwjgl:3.4.1:unsafe"
     ],
     "additionalLibraries": [
       {


### PR DESCRIPTION
For some reason there's a new "unsafe" jar and also a new variant in
26.2-pre-1; not sure why, but gets 26.2-pre-1 building in now

Signed-off-by: crueter <crueter@eden-emu.dev>
